### PR TITLE
Explictly close file handles.

### DIFF
--- a/slic
+++ b/slic
@@ -222,17 +222,19 @@ def main(argv):
             csvfile = open(skiplist, 'rb')
         elif re.match(r"http(s)?://", skiplist):
             csvfile = urllib.urlopen(skiplist)
+        try:
+            csvreader = csv.reader(csvfile)
+            for row in csvreader:
+                if not row or len(row) == 0 or re.search(r"\s*#", row[0]):
+                    next
 
-        csvreader = csv.reader(csvfile)
-        for row in csvreader:
-            if not row or len(row) == 0 or re.search(r"\s*#", row[0]):
-                next
+                log.debug("Row: %r" % row)
+                skip_files.append(row[0].strip())
 
-            log.debug("Row: %r" % row)
-            skip_files.append(row[0].strip())
-
-        log.info("Got skip list; %i entries" % len(skip_files))
-        log.debug("Skip list is:\n%r" % skip_files)
+            log.info("Got skip list; %i entries" % len(skip_files))
+            log.debug("Skip list is:\n%r" % skip_files)
+        finally:
+            csvfile.close()
         
     # Prepare the input.
     if not args:

--- a/slic_results.py
+++ b/slic_results.py
@@ -55,7 +55,8 @@ class SlicResults(dict):
         if re.match(r"^\s*\[", initval):
             data = json.loads(initval)
         else:
-            data = json.load(open(initval))
+            with open(initval, 'r') as jsonfile:
+                data = json.load(jsonfile)
 
         # Rejig data structure so top-level key is the tag instead of the
         # unification hash value, and value is a list of the corresponding

--- a/utils.py
+++ b/utils.py
@@ -23,13 +23,15 @@ _is_binary_string = lambda bytes: bool(bytes.translate(None, _textchars))
 # Stack Overflow 898669
 def is_binary(filename):
     try:
-        data = open(filename, 'rb').read(1024)
-        if not data:
-            # 0-byte file. If a file is 0 bytes, can it truly be said to be
-            # binary or not binary? Deep. Still, we should ignore it.
-            return True
-        else:
-            return _is_binary_string(data)
+
+        with open(filename, 'rb') as binaryfile:
+            data = binaryfile.read(1024)
+            if not data:
+                # 0-byte file. If a file is 0 bytes, can it truly be said to be
+                # binary or not binary? Deep. Still, we should ignore it.
+                return True
+            else:
+                return _is_binary_string(data)
     except IOError:
         log.warning("Can't open file '%s' to see if it's binary", filename)
         return True


### PR DESCRIPTION
Try to ensure file handles are closed sooner in frequently run code.
Without this errors like
IOError: [Errno 24] Too many open files: '5.2/binutils-2.24/ld/scripttempl/armaout.sc'
occur when running slic under PyPy because PyPy garbage collects the
file handles later than regular CPython (see
https://bitbucket.org/pypy/pypy/issues/878/too-many-open-files ).
